### PR TITLE
Hopefully solve GC issue with Queues

### DIFF
--- a/clientagent/client.go
+++ b/clientagent/client.go
@@ -966,6 +966,7 @@ func (c *Client) getDatagramFromQueue() Datagram {
 	defer c.queueLock.Unlock()
 
 	dg := c.queue[0]
+	c.queue[0] = Datagram{}
 	c.queue = c.queue[1:]
 	return dg
 }

--- a/clientagent/clientagent.go
+++ b/clientagent/clientagent.go
@@ -159,6 +159,7 @@ func (c *ClientAgent) getEntryFromQueue() LuaQueueEntry {
 	defer c.Unlock()
 
 	op := c.LQueue[0]
+	c.LQueue[0] = LuaQueueEntry{}
 	c.LQueue = c.LQueue[1:]
 	return op
 }

--- a/database/databaseserver.go
+++ b/database/databaseserver.go
@@ -119,6 +119,7 @@ func (d *DatabaseServer) getOperationFromQueue() OperationQueueEntry {
 	defer d.queueLock.Unlock()
 
 	op := d.queue[0]
+	d.queue[0] = OperationQueueEntry{}
 	d.queue = d.queue[1:]
 	return op
 }

--- a/luarole/luarole.go
+++ b/luarole/luarole.go
@@ -118,6 +118,7 @@ func (l *LuaRole) getEntryFromQueue() LuaQueueEntry {
 	defer l.Unlock()
 
 	op := l.LQueue[0]
+	l.LQueue[0] = LuaQueueEntry{}
 	l.LQueue = l.LQueue[1:]
 	return op
 }

--- a/messagedirector/md.go
+++ b/messagedirector/md.go
@@ -90,6 +90,7 @@ func (m *MessageDirector) getDatagramFromQueue() QueueEntry {
 	defer m.queueLock.Unlock()
 
 	obj := MD.Queue[0]
+	MD.Queue[0] = QueueEntry{}
 	MD.Queue = MD.Queue[1:]
 	return obj
 }


### PR DESCRIPTION
Due to how Go handles appending to slices when the backing array is unable to hold a new element, the Queue slices, over time, grow perpetually larger and larger as Go increases the array size each time from 2x-1.5x the original array size. 

Because of this, Queue elements would struggle to dereference in a timely fashion, simply sitting in the backing array until their array was finally replaced with a larger one. 

Queue elements that reserved memory such as Datagrams would thus keep hold of that memory, unable to be garbage collected during this time.

This change should allow the queue elements to be deallocated the moment it is sensible to do so. While the queues will hold onto a zero value reference, this will still allow the previous elements of the structs to be GCed in a timely fashion.