### PR TITLE
Rework slice element removal logic to prevent elements getting stuck in backing array

### DIFF
--- a/clientagent/clientagent.go
+++ b/clientagent/clientagent.go
@@ -11,12 +11,13 @@ import (
 	. "otpgo/util"
 	"sync"
 
+	"net/http"
+
 	"github.com/apex/log"
 	gluahttp "github.com/cjoudrey/gluahttp"
 	gluacrypto "github.com/tengattack/gluacrypto"
 	libs "github.com/vadv/gopher-lua-libs"
 	lua "github.com/yuin/gopher-lua"
-	"net/http"
 )
 
 type ChannelTracker struct {
@@ -161,6 +162,10 @@ func (c *ClientAgent) getEntryFromQueue() LuaQueueEntry {
 	op := c.LQueue[0]
 	c.LQueue[0] = LuaQueueEntry{}
 	c.LQueue = c.LQueue[1:]
+	if len(c.LQueue) == 0 {
+		// Recreate the queue slice. This prevents the capacity from growing indefinitely and allows old entries to drop off as soon as possible from the backing array.
+		c.LQueue = make([]LuaQueueEntry, 0)
+	}
 	return op
 }
 

--- a/clientagent/wrappers.go
+++ b/clientagent/wrappers.go
@@ -964,11 +964,14 @@ func LuaRemoveSessionObject(L *lua.LState) int {
 	}
 
 	client.log.Debugf("Removed session object with ID %d", do)
-	for i, o := range client.sessionObjects {
-		if o == do {
-			client.sessionObjects = append(client.sessionObjects[:i], client.sessionObjects[i+1:]...)
+
+	tempSessionObjectSlice := make([]Doid_t, 0)
+	for _, o := range client.sessionObjects {
+		if o != do {
+			tempSessionObjectSlice = append(tempSessionObjectSlice, o)
 		}
 	}
+	client.sessionObjects = tempSessionObjectSlice
 	return 1
 }
 

--- a/database/databaseserver.go
+++ b/database/databaseserver.go
@@ -2,12 +2,12 @@ package database
 
 import (
 	"fmt"
+	"os"
+	"os/signal"
 	"otpgo/core"
 	"otpgo/messagedirector"
 	. "otpgo/util"
 	"sync"
-	"os"
-	"os/signal"
 
 	dc "github.com/LittleToonCat/dcparser-go"
 	"github.com/apex/log"
@@ -121,6 +121,10 @@ func (d *DatabaseServer) getOperationFromQueue() OperationQueueEntry {
 	op := d.queue[0]
 	d.queue[0] = OperationQueueEntry{}
 	d.queue = d.queue[1:]
+	if len(d.queue) == 0 {
+		// Recreate the queue slice. This prevents the capacity from growing indefinitely and allows old entries to drop off as soon as possible from the backing array.
+		d.queue = make([]OperationQueueEntry, 0)
+	}
 	return op
 }
 

--- a/luarole/luarole.go
+++ b/luarole/luarole.go
@@ -120,6 +120,10 @@ func (l *LuaRole) getEntryFromQueue() LuaQueueEntry {
 	op := l.LQueue[0]
 	l.LQueue[0] = LuaQueueEntry{}
 	l.LQueue = l.LQueue[1:]
+	if len(l.LQueue) == 0 {
+		// Recreate the queue slice. This prevents the capacity from growing indefinitely and allows old entries to drop off as soon as possible from the backing array.
+		l.LQueue = make([]LuaQueueEntry, 0)
+	}
 	return op
 }
 

--- a/stateserver/distributedobject.go
+++ b/stateserver/distributedobject.go
@@ -707,14 +707,13 @@ func (d *DistributedObject) HandleDatagram(dg Datagram, dgi *DatagramIterator) {
 		oldParent := dgi.ReadDoid()
 		oldZone := dgi.ReadZone()
 		eraseFromSlice := func(slice []Doid_t, element Doid_t) []Doid_t {
-			idx := 0
+			tempSlice := make([]Doid_t, 0)
 			for _, do := range slice {
 				if do != element {
-					slice[idx] = do
-					idx++
+					tempSlice = append(tempSlice, do)
 				}
 			}
-			return slice[:idx]
+			return tempSlice
 		}
 		if newParent == d.do {
 			if d.do == oldParent {


### PR DESCRIPTION
Currently in OtpGo, elements typically get removed from slices by iterating through them and shifting the still-wanted elements to the left. This works fine in the context of the slice, but when it comes to the backing array, the last element would essentially be duplicated as it is not affected by the iteration.

This meant that elements would often get stuck in backing arrays permanently if they were the last element and something else was removed before it was; this is especially bad when it comes to MD participants, as the memory allocation for the pointer could never be freed. 

To solve this, temporary slices are created that have fresh backing arrays, and the still-wanted elements are appended to it before replacing the original slice with the new one. This means that there will not be references to elements lingering in backing arrays, so those elements can get garbage collected if there are no other references to them.

I have also made queues recreate their queue with a fresh slice if they run out of queue elements to process; this is to prevent array allocation from growing indefinitely and to ensure that zero-valued structs can be freed from memory as soon as possible.