### PR TITLE
MD: Make temporary slice copy capacity of the current slice

### DIFF
--- a/messagedirector/md.go
+++ b/messagedirector/md.go
@@ -206,7 +206,7 @@ func (m *MessageDirector) RecallPostRemoves() {
 
 func (m *MessageDirector) RemoveParticipant(p MDParticipant) {
 	m.Lock()
-	tempParticipantSlice := make([]MDParticipant, 0)
+	tempParticipantSlice := make([]MDParticipant, 0, cap(MD.participants))
 	for _, participant := range MD.participants {
 		if participant != p {
 			tempParticipantSlice = append(tempParticipantSlice, participant)


### PR DESCRIPTION
The participants slice is always very large, and we won't ever shrink it, so let's just copy the capacity so `append` does not have to keep making arrays. 