### PR TITLE
Change Time.After to NewTimer 

### DIFF
--- a/net/client.go
+++ b/net/client.go
@@ -144,12 +144,14 @@ func (c *Client) SendDatagram(datagram Datagram) {
 		c.disconnect(err)
 	}
 
+	writeTimer := time.NewTimer(c.timeout)
 	select {
 	case err := <-c.tr.Flush():
+		writeTimer.Stop()
 		if err != nil {
 			c.disconnect(err)
 		}
-	case <-time.After(c.timeout):
+	case <- writeTimer.C:
 		c.disconnect(errors.New("write timeout"))
 	}
 

--- a/net/client.go
+++ b/net/client.go
@@ -147,11 +147,13 @@ func (c *Client) SendDatagram(datagram Datagram) {
 	writeTimer := time.NewTimer(c.timeout)
 	select {
 	case err := <-c.tr.Flush():
-		writeTimer.Stop()
+		if !writeTimer.Stop() {
+			<-writeTimer.C
+		}
 		if err != nil {
 			c.disconnect(err)
 		}
-	case <- writeTimer.C:
+	case <-writeTimer.C:
 		c.disconnect(errors.New("write timeout"))
 	}
 


### PR DESCRIPTION
`time.after`'s Timer does not get garbage collected until the timer fires. Since we have relatively long timeouts, this can result in many Timers remaining in memory even after successfully flushing the data.

Instead, we should call `NewTimer` ourselves and `Stop` it if the Flush channel is met first.