### PR TITLE
DO: Implement preallocation and sync.Pool support for DOs, Client

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -1,9 +1,10 @@
 package core
 
 import (
-	dc "github.com/LittleToonCat/dcparser-go"
-	"otpgo/util"
 	"fmt"
+	"otpgo/util"
+
+	dc "github.com/LittleToonCat/dcparser-go"
 	"github.com/spf13/viper"
 )
 
@@ -49,6 +50,7 @@ type Role struct {
 		ID        int
 		Class     string
 	}
+	DO_Preallocation_Amount int
 
 	// DBSS
 	Ranges struct {

--- a/messagedirector/participant.go
+++ b/messagedirector/participant.go
@@ -123,6 +123,17 @@ func (m *MDParticipantBase) Cleanup() {
 	MD.RemoveParticipant(m)
 }
 
+func (m *MDParticipantBase) RecycleParticipant() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.subscriber = nil
+	clear(m.postRemoves)
+	m.name = ""
+	m.url = ""
+	m.terminated = false
+}
+
 func (m *MDParticipantBase) Terminate(err error) { /* virtual */ }
 
 // MDNetworkParticipant represents a downstream MD connection

--- a/net/client.go
+++ b/net/client.go
@@ -127,15 +127,17 @@ func (c *Client) processInput(len int, data []byte) {
 }
 
 func (c *Client) read() {
-	buff := c.readBufferPool.Get().(*[]byte)
-	// Make sure the buffer is zeroed.
-	clear(*buff)
-	if n, err := c.tr.Read(*buff); err == nil {
-		c.processInput(n, (*buff)[0:n])
-		c.readBufferPool.Put(buff)
-		c.read()
-	} else {
-		c.disconnect(err)
+	for {
+		buff := c.readBufferPool.Get().(*[]byte)
+		// Make sure the buffer is zeroed.
+		clear(*buff)
+		if n, err := c.tr.Read(*buff); err == nil {
+			c.processInput(n, (*buff)[0:n])
+			c.readBufferPool.Put(buff)
+		} else {
+			c.disconnect(err)
+			return
+		}
 	}
 }
 

--- a/net/client.go
+++ b/net/client.go
@@ -158,7 +158,7 @@ func (c *Client) SendDatagram(datagram Datagram) {
 
 	select {
 	case err := <-c.tr.Flush():
-		if writeTimer.Stop() {
+		if !writeTimer.Stop() {
 			<-writeTimer.C
 		}
 		if err != nil {

--- a/stateserver/dostorage.go
+++ b/stateserver/dostorage.go
@@ -1,0 +1,81 @@
+// A storage for preallocated DistributedObjects.
+package stateserver
+
+import (
+	"fmt"
+	. "otpgo/util"
+	"sync"
+
+	dc "github.com/LittleToonCat/dcparser-go"
+	"github.com/apex/log"
+)
+
+type DOStorage struct {
+	DOPool sync.Pool
+}
+
+func NewDOStorage(preallocNum int) *DOStorage {
+	doStore := &DOStorage{
+		DOPool: sync.Pool{
+			New: func() any {
+				return &DistributedObject{requiredFields: make(map[dc.DCField][]byte), 
+					ramFields: make(map[dc.DCField][]byte), 
+					zoneObjects: make(map[Zone_t][]Doid_t),
+				}
+			},
+		},
+	}
+
+	for i := 0; i < preallocNum; i++ {
+		do := &DistributedObject{requiredFields: make(map[dc.DCField][]byte), 
+			ramFields: make(map[dc.DCField][]byte), 
+			zoneObjects: make(map[Zone_t][]Doid_t),
+		}
+		doStore.DOPool.Put(do)
+	}
+	
+	return doStore
+} 
+
+func (doStore *DOStorage) recycleDO(do *DistributedObject) {
+	do.log = nil
+	do.stateserver = nil
+	do.do = 0
+	do.parent = 0
+	do.zone = 0
+	do.dclass = nil
+	// We want to reuse the maps where possible; these are already cleared on annihilation. 
+	do.aiChannel = 0
+	do.ownerChannel = 0
+	do.explicitAi = false
+	do.parentSynchronized = false
+
+	doStore.DOPool.Put(do)
+}
+
+func (doStore *DOStorage) createDO(ss *StateServer, doid Doid_t, 
+	dclass dc.DCClass, requiredFields FieldValues,
+	ramFields FieldValues) *DistributedObject {
+		do  := doStore.DOPool.Get().(*DistributedObject)
+		do.log = log.WithFields(log.Fields{
+			"name":    fmt.Sprintf("%s (%d)", dclass.Get_name(), doid),
+			"modName": dclass.Get_name(),
+			"id":      fmt.Sprintf("%d", doid),
+		})
+		do.stateserver = ss
+		do.do = doid
+		do.zone = INVALID_ZONE
+		do.dclass = dclass
+		
+		if (requiredFields != nil) {
+			do.requiredFields = requiredFields
+		}
+
+		if (ramFields != nil) {
+			do.ramFields = ramFields
+		}
+
+		// All DistributedObjects reuse their zoneObjects map, so we don't need to set it here.
+
+		return do
+	}

--- a/stateserver/dostorage.go
+++ b/stateserver/dostorage.go
@@ -49,7 +49,7 @@ func (doStore *DOStorage) recycleDO(do *DistributedObject) {
 	do.ownerChannel = 0
 	do.explicitAi = false
 	do.parentSynchronized = false
-
+	do.RecycleParticipant()
 	doStore.DOPool.Put(do)
 }
 

--- a/stateserver/stateserver.go
+++ b/stateserver/stateserver.go
@@ -1,12 +1,13 @@
 package stateserver
 
 import (
+	"fmt"
 	"otpgo/core"
 	"otpgo/messagedirector"
 	. "otpgo/util"
-	"fmt"
-	"github.com/apex/log"
+
 	dc "github.com/LittleToonCat/dcparser-go"
+	"github.com/apex/log"
 )
 
 type StateServer struct {
@@ -16,7 +17,8 @@ type StateServer struct {
 	log     *log.Entry
 	control Channel_t
 	objects map[Doid_t]*DistributedObject
-	mainObj *DistributedObject;
+	mainObj *DistributedObject
+	doStore *DOStorage
 }
 
 func NewStateServer(config core.Role) *StateServer {
@@ -38,6 +40,8 @@ func NewStateServer(config core.Role) *StateServer {
 
 func (s *StateServer) InitStateServer(config core.Role, logName string, logModName string, logId string,) {
 	s.config = config
+	doPreallocAmount := s.config.DO_Preallocation_Amount
+	s.doStore = NewDOStorage(doPreallocAmount)
 	s.objects = map[Doid_t]*DistributedObject{}
 	s.log = log.WithFields(log.Fields{
 		"name": logName,


### PR DESCRIPTION
OtpGo currently makes many allocations that can preferably be reused instead. DOs are constantly allocated, which could cause problems in environments where the GC cannot trigger often enough. We would prefer to reuse this memory instead, so I have implemented a sync.Pool storage that has an optional `DO_Preallocation_Amount` config var that will preallocate DOs into the pool.

I have also placed client read buffers into a pool so they can also be reused without being constantly allocated, and each client now has a timeout timer they keep reference to.