### PR TITLE
Lua: Add mutex for the context maps.

### DIFF
--- a/luarole/luarole.go
+++ b/luarole/luarole.go
@@ -27,6 +27,9 @@ type LuaQueueEntry struct {
 type LuaRole struct {
 	messagedirector.MDParticipantBase
 	sync.Mutex
+	cMapLock sync.Mutex
+	gMapLock sync.Mutex
+	qMapLock sync.Mutex
 
 	config core.Role
 	log    *log.Entry
@@ -191,6 +194,9 @@ func (l *LuaRole) HandleDatagram(dg Datagram, dgi *DatagramIterator) {
 }
 
 func (c *LuaRole) createDatabaseObject(dbChannel Channel_t, objectType uint16, packedValues map[string]dc.Vector_uchar, from Channel_t, callback func(doId Doid_t)) {
+	c.cMapLock.Lock()
+	defer c.cMapLock.Unlock()
+	
 	c.createContextMap[c.context] = callback
 
 	dg := NewDatagram()
@@ -211,7 +217,10 @@ func (c *LuaRole) createDatabaseObject(dbChannel Channel_t, objectType uint16, p
 }
 
 func (c *LuaRole) handleCreateDatabaseResp(context uint32, code uint8, doId Doid_t) {
+	c.cMapLock.Lock()
 	callback, ok := c.createContextMap[context]
+	c.cMapLock.Unlock()
+
 	if !ok {
 		c.log.Warnf("Got CreateDatabaseRsp with missing context %d", context)
 		return
@@ -222,10 +231,16 @@ func (c *LuaRole) handleCreateDatabaseResp(context uint32, code uint8, doId Doid
 	}
 
 	callback(doId)
+
+	c.cMapLock.Lock()
 	delete(c.createContextMap, context)
+	c.cMapLock.Unlock()
 }
 
 func (l *LuaRole) getDatabaseValues(dbChannel Channel_t, doId Doid_t, fields []string, from Channel_t, callback func(doId Doid_t, dgi *DatagramIterator)) {
+	l.gMapLock.Lock()
+	defer l.gMapLock.Unlock()
+	
 	l.getContextMap[l.context] = callback
 
 	dg := NewDatagram()
@@ -244,14 +259,20 @@ func (l *LuaRole) handleGetStoredValuesResp(dgi *DatagramIterator) {
 	context := dgi.ReadUint32()
 	doId := dgi.ReadDoid()
 
+	l.gMapLock.Lock()
 	callback, ok := l.getContextMap[context]
+	l.gMapLock.Unlock()
+
 	if !ok {
 		l.log.Warnf("Got GetStoredResp with missing context %d", context)
 		return
 	}
 
 	callback(doId, dgi)
+
+	l.gMapLock.Lock()
 	delete(l.getContextMap, context)
+	l.gMapLock.Unlock()
 }
 
 func (l *LuaRole) handleQueryFieldsResp(dgi *DatagramIterator) {
@@ -259,14 +280,20 @@ func (l *LuaRole) handleQueryFieldsResp(dgi *DatagramIterator) {
 
 	context := dgi.ReadUint32()
 
+	l.qMapLock.Lock()
 	callback, ok := l.queryContextMap[context]
+	l.qMapLock.Unlock()
+
 	if !ok {
 		l.log.Warnf("Got QueryFieldsResp with missing context %d", context)
 		return
 	}
 
 	callback(dgi)
+
+	l.qMapLock.Lock()
 	delete(l.queryContextMap, context)
+	l.qMapLock.Unlock()
 }
 
 func (l *LuaRole) setDatabaseValues(doId Doid_t, dbChannel Channel_t, packedValues map[string]dc.Vector_uchar) {

--- a/luarole/luarole.go
+++ b/luarole/luarole.go
@@ -27,9 +27,9 @@ type LuaQueueEntry struct {
 type LuaRole struct {
 	messagedirector.MDParticipantBase
 	queueLock sync.Mutex
-	cMapLock sync.Mutex
-	gMapLock sync.Mutex
-	qMapLock sync.Mutex
+	cMapLock sync.RWMutex
+	gMapLock sync.RWMutex
+	qMapLock sync.RWMutex
 
 	config core.Role
 	log    *log.Entry
@@ -217,9 +217,9 @@ func (c *LuaRole) createDatabaseObject(dbChannel Channel_t, objectType uint16, p
 }
 
 func (c *LuaRole) handleCreateDatabaseResp(context uint32, code uint8, doId Doid_t) {
-	c.cMapLock.Lock()
+	c.cMapLock.RLock()
 	callback, ok := c.createContextMap[context]
-	c.cMapLock.Unlock()
+	c.cMapLock.RUnlock()
 
 	if !ok {
 		c.log.Warnf("Got CreateDatabaseRsp with missing context %d", context)
@@ -259,9 +259,9 @@ func (l *LuaRole) handleGetStoredValuesResp(dgi *DatagramIterator) {
 	context := dgi.ReadUint32()
 	doId := dgi.ReadDoid()
 
-	l.gMapLock.Lock()
+	l.gMapLock.RLock()
 	callback, ok := l.getContextMap[context]
-	l.gMapLock.Unlock()
+	l.gMapLock.RUnlock()
 
 	if !ok {
 		l.log.Warnf("Got GetStoredResp with missing context %d", context)
@@ -280,9 +280,9 @@ func (l *LuaRole) handleQueryFieldsResp(dgi *DatagramIterator) {
 
 	context := dgi.ReadUint32()
 
-	l.qMapLock.Lock()
+	l.qMapLock.RLock()
 	callback, ok := l.queryContextMap[context]
-	l.qMapLock.Unlock()
+	l.qMapLock.RUnlock()
 
 	if !ok {
 		l.log.Warnf("Got QueryFieldsResp with missing context %d", context)

--- a/luarole/wrappers.go
+++ b/luarole/wrappers.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 
 	dc "github.com/LittleToonCat/dcparser-go"
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 // Participant wrappers for Lua
@@ -455,6 +455,9 @@ func LuaQueryObjectFields(L *lua.LState) int {
 		participant.CallLuaFunction(callback, senderContext, lua.LNumber(doId), lua.LTrue, fieldTable)
 	}
 
+	participant.qMapLock.Lock()
+	defer participant.qMapLock.Unlock()
+	
 	participant.queryContextMap[participant.context] = callbackFunc
 
 	dg := NewDatagram()


### PR DESCRIPTION
`LuaRole` had concurrency issues with its maps, so mutexes were added to solve this. 