### PR TITLE
CA, Lua: Make context value atomic, add RWMutexes for CA

### DIFF
--- a/clientagent/client.go
+++ b/clientagent/client.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"sort"
 	"strconv"
+	"sync/atomic"
 
 	"fmt"
 	gonet "net"
@@ -76,13 +77,16 @@ type Client struct {
 	state            ClientState
 	authenticated    bool
 
-	context          uint32
+	context          atomic.Uint32
 	createContextMap map[uint32]func(doId Doid_t)
 	getContextMap    map[uint32]func(doId Doid_t, dgi *DatagramIterator)
 	queryFieldsContextMap    map[uint32]func(dgi *DatagramIterator)
 
 	queue         []Datagram
 	queueLock     sync.Mutex
+	cMapLock      sync.RWMutex
+	gMapLock      sync.RWMutex
+	qMapLock      sync.RWMutex
 	shouldProcess chan bool
 	stopChan      chan bool
 
@@ -266,14 +270,14 @@ func (c *Client) addInterest(i Interest, context uint32, caller Channel_t) {
 	}
 
 	// Build a new IOP otherwise
-	c.context++
+	iopContext := c.context.Add(1)
 	iop := NewInterestOperation(c, c.config.Tuning.Interest_Timeout, i.id,
-		context, c.context, i.parent, zones, caller)
-	c.pendingInterests[c.context] = iop
+		context, iopContext, i.parent, zones, caller)
+	c.pendingInterests[iopContext] = iop
 
 	resp := NewDatagram()
 	resp.AddServerHeader(Channel_t(i.parent), c.channel, STATESERVER_OBJECT_GET_ZONES_OBJECTS)
-	resp.AddUint32(c.context)
+	resp.AddUint32(iopContext)
 	resp.AddDoid(i.parent)
 	resp.AddUint16(uint16(len(zones)))
 	for _, zone := range zones {
@@ -1042,11 +1046,15 @@ func (c *Client) handleHeartbeat() {
 }
 
 func (c *Client) createDatabaseObject(objectType uint16, packedValues map[string]dc.Vector_uchar, callback func(doId Doid_t)) {
-	c.createContextMap[c.context] = callback
+	c.cMapLock.Lock()
+	defer c.cMapLock.Unlock()
+
+	context := c.context.Add(1)
+	c.createContextMap[context] = callback
 
 	dg := NewDatagram()
 	dg.AddServerHeader(c.ca.database, c.channel, DBSERVER_CREATE_STORED_OBJECT)
-	dg.AddUint32(c.context)
+	dg.AddUint32(context)
 	dg.AddString("") // Unknown
 	dg.AddUint16(objectType)
 	dg.AddUint16(uint16(len(packedValues)))
@@ -1058,11 +1066,13 @@ func (c *Client) createDatabaseObject(objectType uint16, packedValues map[string
 		dc.DeleteVector_uchar(value)
 	}
 	c.RouteDatagram(dg)
-	c.context++
 }
 
 func (c *Client) handleCreateDatabaseResp(context uint32, code uint8, doId Doid_t) {
+	c.cMapLock.RLock()
 	callback, ok := c.createContextMap[context]
+	c.cMapLock.RUnlock()
+
 	if !ok {
 		c.log.Warnf("Got CreateDatabaseRsp with missing context %d", context)
 		return
@@ -1073,36 +1083,48 @@ func (c *Client) handleCreateDatabaseResp(context uint32, code uint8, doId Doid_
 	}
 
 	callback(doId)
+
+	c.cMapLock.Lock()
 	delete(c.createContextMap, context)
+	c.cMapLock.Unlock()
 }
 
 func (c *Client) getDatabaseValues(doId Doid_t, fields []string, callback func(doId Doid_t, dgi *DatagramIterator)) {
-	c.getContextMap[c.context] = callback
+	c.gMapLock.Lock()
+	defer c.gMapLock.Unlock()
+
+	context := c.context.Add(1)
+	c.getContextMap[context] = callback
 
 	dg := NewDatagram()
 	dg.AddServerHeader(c.ca.database, c.channel, DBSERVER_GET_STORED_VALUES)
-	dg.AddUint32(c.context)
+	dg.AddUint32(context)
 	dg.AddDoid(doId)
 	dg.AddUint16(uint16(len(fields)))
 	for _, name := range fields {
 		dg.AddString(name)
 	}
 	c.RouteDatagram(dg)
-	c.context++
 }
 
 func (c *Client) handleGetStoredValuesResp(dgi *DatagramIterator) {
 	context := dgi.ReadUint32()
 	doId := dgi.ReadDoid()
 
+	c.gMapLock.RLock()
 	callback, ok := c.getContextMap[context]
+	c.gMapLock.RUnlock()
+
 	if !ok {
 		c.log.Warnf("Got GetStoredResp with missing context %d", context)
 		return
 	}
 
 	callback(doId, dgi)
+
+	c.gMapLock.Lock()
 	delete(c.getContextMap, context)
+	c.gMapLock.Unlock()
 }
 
 func (c *Client) handleQueryFieldsResp(dgi *DatagramIterator) {
@@ -1110,14 +1132,20 @@ func (c *Client) handleQueryFieldsResp(dgi *DatagramIterator) {
 
 	context := dgi.ReadUint32()
 
+	c.qMapLock.RLock()
 	callback, ok := c.queryFieldsContextMap[context]
+	c.qMapLock.RUnlock()
+
 	if !ok {
 		c.log.Warnf("Got QueryFieldsResp with missing context %d", context)
 		return
 	}
 
 	callback(dgi)
+
+	c.qMapLock.Lock()
 	delete(c.queryFieldsContextMap, context)
+	c.qMapLock.Unlock()
 }
 
 func (c *Client) setDatabaseValues(doId Doid_t, packedValues map[string]dc.Vector_uchar) {

--- a/clientagent/wrappers.go
+++ b/clientagent/wrappers.go
@@ -579,17 +579,20 @@ func LuaQueryObjectFields(L *lua.LState) int {
 		client.ca.CallLuaFunction(callback, client, lua.LNumber(doId), lua.LTrue, fieldTable)
 	}
 
-	client.queryFieldsContextMap[client.context] = callbackFunc
+	client.qMapLock.Lock()
+	defer client.qMapLock.Unlock()
+
+	context := client.context.Add(1)
+	client.queryFieldsContextMap[context] = callbackFunc
 
 	dg := NewDatagram()
 	dg.AddServerHeader(Channel_t(doId), client.channel, STATESERVER_OBJECT_QUERY_FIELDS)
 	dg.AddDoid(doId)
-	dg.AddUint32(client.context)
+	dg.AddUint32(context)
 	for _, fieldId := range fieldIds {
 		dg.AddUint16(fieldId)
 	}
 	client.RouteDatagram(dg)
-	client.context++
 	return 1
 }
 
@@ -665,17 +668,20 @@ func LuaQueryAllRequiredFields(L *lua.LState) int {
 		client.ca.CallLuaFunction(callback, client, lua.LNumber(doId), lua.LTrue, resultTable)
 	}
 
-	client.queryFieldsContextMap[client.context] = callbackFunc
+	client.qMapLock.Lock()
+	defer client.qMapLock.Unlock()
+
+	context := client.context.Add(1)
+	client.queryFieldsContextMap[context] = callbackFunc
 
 	dg := NewDatagram()
 	dg.AddServerHeader(Channel_t(doId), client.channel, STATESERVER_OBJECT_QUERY_FIELDS)
 	dg.AddDoid(doId)
-	dg.AddUint32(client.context)
+	dg.AddUint32(context)
 	for _, fieldId := range fieldIds {
 		dg.AddUint16(fieldId)
 	}
 	client.RouteDatagram(dg)
-	client.context++
 	return 1
 }
 

--- a/luarole/wrappers.go
+++ b/luarole/wrappers.go
@@ -458,17 +458,17 @@ func LuaQueryObjectFields(L *lua.LState) int {
 	participant.qMapLock.Lock()
 	defer participant.qMapLock.Unlock()
 	
-	participant.queryContextMap[participant.context] = callbackFunc
+	context := participant.context.Add(1)
+	participant.queryContextMap[context] = callbackFunc
 
 	dg := NewDatagram()
 	dg.AddServerHeader(Channel_t(doId), from, STATESERVER_OBJECT_QUERY_FIELDS)
 	dg.AddDoid(doId)
-	dg.AddUint32(participant.context)
+	dg.AddUint32(context)
 	for _, fieldId := range fieldIds {
 		dg.AddUint16(fieldId)
 	}
 	participant.RouteDatagram(dg)
-	participant.context++
 	return 1
 }
 


### PR DESCRIPTION
CA had the same issue as `LuaRole` regarding its maps. Also made the context values for `LuaRole` and CA atomic so modifications by other goroutines do not impact one another.