### PR TITLE
CA/MD: Fix some potential concurrency issues

### DIFF
--- a/messagedirector/participant.go
+++ b/messagedirector/participant.go
@@ -207,6 +207,9 @@ func (m *MDNetworkParticipant) ReceiveDatagram(dg Datagram) {
 }
 
 func (m *MDNetworkParticipant) Terminate(err error) {
+	if m.terminated {
+		return
+	}
 	MDLog.Infof("Lost connection from %s: %s", m.conn.RemoteAddr(), err.Error())
 	m.Cleanup()
 	m.client.Close()

--- a/net/client.go
+++ b/net/client.go
@@ -176,12 +176,16 @@ func (c *Client) SendDatagram(datagram Datagram) {
 func (c *Client) Close() {
 	c.Mutex.Lock()
 	defer c.Mutex.Unlock()
-	c.tr.Close()
+	if c.Connected() {
+		c.tr.Close()
+	}
 }
 
 func (c *Client) disconnect(err error) {
 	c.Mutex.Lock()
-	c.tr.Close()
+	if c.Connected() {
+		c.tr.Close()
+	}
 	c.Mutex.Unlock()
 	c.handler.Terminate(err)
 }


### PR DESCRIPTION
IOPs would get stuck with a goroutine writing to `finishedChan` if they timed out since the select statement had already finished at that point, so I added a boolean to indicate whether they timed out and only write to `finishedChan` if they didn't time out. 

Also there were potential issues with multiple client terminations/transport closures that should be resolved now.