### PR TITLE
client: Adjust transport closing mutex logic to prevent deadlock 

### DIFF
--- a/clientagent/client.go
+++ b/clientagent/client.go
@@ -986,7 +986,7 @@ func (c *Client) Terminate(err error) {
 	}()
 	go c.annihilate()
 
-	c.client.Close()
+	c.client.Close(true)
 }
 
 func (c *Client) ReceiveDatagram(dg Datagram) {

--- a/messagedirector/md_test.go
+++ b/messagedirector/md_test.go
@@ -44,9 +44,9 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 
 	// TEARDOWN
-	mainClient.Close()
-	client1.Close()
-	client2.Close()
+	mainClient.Close(true)
+	client1.Close(true)
+	client2.Close(true)
 	os.Exit(code)
 }
 
@@ -112,7 +112,7 @@ func TestMD_Subscribe(t *testing.T) {
 	client1.ExpectNone(t)            // Should not be echoed back
 
 	// CLose the second connection, auto-unsubscribing it
-	client2.Close()
+	client2.Close(true)
 	client2 = (&TestMDConnection{}).Connect(":57123", "client #2")
 	client1.ExpectNone(t)
 	// MD should unsubscribe from parent
@@ -210,7 +210,7 @@ func TestMD_PostRemove(t *testing.T) {
 	client2.ExpectNone(t)
 
 	// Reconnect and see if the PR gets sent
-	client1.Close()
+	client1.Close(true)
 	client1 = (&TestMDConnection{}).Connect(":57123", "client #1")
 
 	// Upstream should receive the PR and a clear_post_remove
@@ -218,7 +218,7 @@ func TestMD_PostRemove(t *testing.T) {
 	mainClient.ExpectMany(t, []Datagram{*prDg, *clearPrDg}, false, true)
 
 	// Reconnect; the PR shouldn't be sent again
-	client1.Close()
+	client1.Close(true)
 	client1 = (&TestMDConnection{}).Connect(":57123", "client #1")
 	mainClient.ExpectNone(t)
 
@@ -233,7 +233,7 @@ func TestMD_PostRemove(t *testing.T) {
 	mainClient.Expect(t, *clearPrDg, false)
 
 	// Did it work?
-	client2.Close()
+	client2.Close(true)
 	client2 = (&TestMDConnection{}).Connect(":57123", "client #2")
 	mainClient.ExpectNone(t)
 
@@ -258,7 +258,7 @@ func TestMD_PostRemove(t *testing.T) {
 	client2.ExpectNone(t)
 
 	// Reconnect and see if all of the datagrams get sent
-	client1.Close()
+	client1.Close(true)
 	client1 = (&TestMDConnection{}).Connect(":57123", "client #1")
 
 	expected := []Datagram{
@@ -385,7 +385,7 @@ func TestMD_Ranges(t *testing.T) {
 	})
 
 	// When client one dies, it's last remaining range should die
-	client1.Close()
+	client1.Close(true)
 	client1 = (&TestMDConnection{}).Connect(":57123", "client #1")
 	mainClient.Expect(t, *(&TestDatagram{}).CreateRemoveRange(2000, 2100), false)
 	mainClient.ExpectNone(t)
@@ -575,7 +575,7 @@ func TestMD_Ranges(t *testing.T) {
 		4763: false,
 	})
 
-	client2.Close()
+	client2.Close(true)
 	client2 = (&TestMDConnection{}).Connect(":57123", "client #2")
 	mainClient.Expect(t, *(&TestDatagram{}).CreateRemoveRange(3500, 3525), false)
 	mainClient.ExpectNone(t)
@@ -593,7 +593,7 @@ func TestMD_Ranges(t *testing.T) {
 	}, false, false)
 
 	// Now we have a fully functional MD!
-	client1.Close()
-	client2.Close()
-	mainClient.Close()
+	client1.Close(true)
+	client2.Close(true)
+	mainClient.Close(true)
 }

--- a/messagedirector/participant.go
+++ b/messagedirector/participant.go
@@ -212,5 +212,5 @@ func (m *MDNetworkParticipant) Terminate(err error) {
 	}
 	MDLog.Infof("Lost connection from %s: %s", m.conn.RemoteAddr(), err.Error())
 	m.Cleanup()
-	m.client.Close()
+	m.client.Close(true)
 }

--- a/messagedirector/upstream.go
+++ b/messagedirector/upstream.go
@@ -87,6 +87,6 @@ func (m *MDUpstream) ReceiveDatagram(datagram Datagram) {
 
 func (m *MDUpstream) Terminate(err error) {
 	MDLog.Fatalf("Lost connection to upstream MD: %s", err)
-	m.client.Close()
+	m.client.Close(true)
 	os.Exit(0)
 }

--- a/net/client.go
+++ b/net/client.go
@@ -186,6 +186,8 @@ func (c *Client) Close(needsLock bool) {
 	}
 }
 
+// disconnect disconnects the client. 
+// needsLock indicates whether the transport closing should try and acquire the client mutex; if the caller already has the mutex, set this to false. 
 func (c *Client) disconnect(err error, needsLock bool) {
 	c.Close(needsLock)
 	c.handler.Terminate(err)

--- a/test/testing.go
+++ b/test/testing.go
@@ -1,13 +1,13 @@
 package test
 
 import (
+	"encoding/hex"
+	"fmt"
+	gonet "net"
 	"otpgo/core"
 	"otpgo/eventlogger"
 	"otpgo/net"
 	. "otpgo/util"
-	"encoding/hex"
-	"fmt"
-	gonet "net"
 	"reflect"
 	"strings"
 	"testing"
@@ -510,5 +510,5 @@ func (c *TestChannelConnection) ClearChannels() {
 
 func (c *TestChannelConnection) Close() {
 	c.ClearChannels()
-	c.TestMDConnection.Close()
+	c.TestMDConnection.Close(true)
 }


### PR DESCRIPTION
Since `disconnect` and `Close` were sometimes called with varying state of client mutex locks, I've adjusted the functions to require indication on whether or not they should try and acquire it.