### PR TITLE
MD: Allow datagrams to be queued early

### DIFF
--- a/messagedirector/participant.go
+++ b/messagedirector/participant.go
@@ -54,7 +54,11 @@ func (m *MDParticipantBase) Subscriber() *Subscriber {
 
 func (m *MDParticipantBase) RouteDatagram(datagram Datagram) {
 	MD.queueLock.Lock()
-	MD.Queue = append(MD.Queue, QueueEntry{datagram, m})
+	nextPos := MD.queuePreviousStoredPosition.Add(1)
+	queueEntry := QueueEntry{datagram, m}
+	queueSlice := make([]QueueEntry, 0)
+	queueSlice = append(queueSlice, queueEntry)
+	MD.Queue[nextPos] = queueSlice
 	MD.queueLock.Unlock()
 
 	select {

--- a/messagedirector/participant.go
+++ b/messagedirector/participant.go
@@ -14,6 +14,7 @@ type MDParticipant interface {
 
 	// RouteDatagram routes a datagram through the MD
 	RouteDatagram(Datagram)
+	RouteDatagramEarly(Datagram)
 
 	SubscribeChannel(Channel_t)
 	UnsubscribeChannel(Channel_t)
@@ -52,6 +53,7 @@ func (m *MDParticipantBase) Subscriber() *Subscriber {
 	return m.subscriber
 }
 
+// RouteDatagram appends a datagram to the end of the MD queue.
 func (m *MDParticipantBase) RouteDatagram(datagram Datagram) {
 	MD.queueLock.Lock()
 	nextPos := MD.queuePreviousStoredPosition.Add(1)
@@ -59,6 +61,30 @@ func (m *MDParticipantBase) RouteDatagram(datagram Datagram) {
 	queueSlice := make([]QueueEntry, 0)
 	queueSlice = append(queueSlice, queueEntry)
 	MD.Queue[nextPos] = queueSlice
+	MD.queueLock.Unlock()
+
+	select {
+	case MD.shouldProcess <- true:
+	default:
+	}
+}
+
+// RouteDatagramEarly appends a datagram to the end of the current queue entry that will be processed.
+// This is used to keep datagrams in the same flow together, so they can be processed in the expected order.
+func (m *MDParticipantBase) RouteDatagramEarly(datagram Datagram) {
+	MD.queueLock.Lock()
+	curPos := MD.queueCurrentPosition.Load()
+	queueEntry := QueueEntry{datagram, m}
+	_, ok := MD.Queue[curPos] 
+	if !ok {
+		// This entry isn't in the queue yet. Make a new one.
+		queueSlice := make([]QueueEntry, 0)
+		queueSlice = append(queueSlice, queueEntry)
+		MD.Queue[curPos] = queueSlice
+	} else {
+		// Entry is in the map. Append this datagram to the end of this entry.
+		MD.Queue[curPos] = append(MD.Queue[curPos], queueEntry) 
+	}
 	MD.queueLock.Unlock()
 
 	select {

--- a/messagedirector/upstream.go
+++ b/messagedirector/upstream.go
@@ -76,7 +76,11 @@ func (m *MDUpstream) HandleDatagram(datagram Datagram, dgi *DatagramIterator) {
 
 func (m *MDUpstream) ReceiveDatagram(datagram Datagram) {
 	MD.queueLock.Lock()
-	MD.Queue = append(MD.Queue, QueueEntry{datagram, nil})
+	nextPos := MD.queuePreviousStoredPosition.Add(1)
+	queueEntry := QueueEntry{datagram, nil}
+	queueSlice := make([]QueueEntry, 0)
+	queueSlice = append(queueSlice, queueEntry)
+	MD.Queue[nextPos] = queueSlice
 	MD.queueLock.Unlock()
 
 	select {

--- a/stateserver/dbstateserver.go
+++ b/stateserver/dbstateserver.go
@@ -376,7 +376,7 @@ func (s *DatabaseStateServer) handleOneUpdate(dgi *DatagramIterator) {
 	dg.AddUint16(uint16(len(data)))
 	dg.AddData(data)
 
-	s.RouteDatagram(dg)
+	s.RouteDatagramEarly(dg)
 }
 
 func (s *DatabaseStateServer) handleMultipleUpdates(dgi *DatagramIterator) {
@@ -439,7 +439,7 @@ func (s *DatabaseStateServer) handleMultipleUpdates(dgi *DatagramIterator) {
 		dg.AddData(data)
 	}
 
-	s.RouteDatagram(dg)
+	s.RouteDatagramEarly(dg)
 
 }
 

--- a/stateserver/distributedobject.go
+++ b/stateserver/distributedobject.go
@@ -251,7 +251,7 @@ func (d *DistributedObject) sendLocationEntry(location Channel_t) {
 	if len(d.ramFields) != 0 {
 		d.appendOtherData(dg, true)
 	}
-	d.RouteDatagram(dg)
+	d.RouteDatagramEarly(dg)
 }
 
 func (d *DistributedObject) sendAiEntry(ai Channel_t, sender Channel_t) {
@@ -316,7 +316,7 @@ func (d *DistributedObject) handleLocationChange(parent Doid_t, zone Zone_t, sen
 				// dg.AddUint32(d.context)
 				// Send our sender as the context
 				dg.AddUint32(uint32(sender)) // prob a bad idea to convert this but...
-				d.RouteDatagram(dg)
+				d.RouteDatagramEarly(dg)
 				// d.context++
 			}
 			targets = append(targets, Channel_t(parent))
@@ -341,7 +341,7 @@ func (d *DistributedObject) handleLocationChange(parent Doid_t, zone Zone_t, sen
 	dg.AddDoid(d.do)
 	dg.AddLocation(parent, zone)
 	dg.AddLocation(oldParent, oldZone)
-	d.RouteDatagram(dg)
+	d.RouteDatagramEarly(dg)
 
 	d.parentSynchronized = false
 
@@ -455,7 +455,7 @@ func (d *DistributedObject) saveField(field dc.DCField, data []byte) bool {
 		dg.AddUint16(uint16(len(data)))
 		dg.AddData(data)
 
-		d.RouteDatagram(dg)
+		d.RouteDatagramEarly(dg)
 	}
 
 	if field.IsRequired() {
@@ -559,7 +559,7 @@ func (d *DistributedObject) finishHandleUpdate(field dc.DCField, data []byte, se
 		dg.AddDoid(d.do)
 		dg.AddUint16(uint16(field.GetNumber()))
 		dg.AddData(data)
-		d.RouteDatagram(dg)
+		d.RouteDatagramEarly(dg)
 	}
 }
 
@@ -740,7 +740,7 @@ func (d *DistributedObject) HandleDatagram(dg Datagram, dgi *DatagramIterator) {
 			dg.AddServerHeader(Channel_t(child), Channel_t(d.do), STATESERVER_OBJECT_LOCATION_ACK)
 			dg.AddDoid(d.do)
 			dg.AddZone(newZone)
-			d.RouteDatagram(dg)
+			d.RouteDatagramEarly(dg)
 		} else if oldParent == d.do {
 			d.zoneObjects[oldZone] = eraseFromSlice(d.zoneObjects[oldZone], child)
 			if len(d.zoneObjects[oldZone]) == 0 {


### PR DESCRIPTION
Currently, the MD queue system expects every datagram to be added to it sequentially. This causes issues when a datagram being processed creates more datagrams; these new datagrams always get appended to the end of the queue, which can cause some datagrams to ultimately finish their process later than those that entered later.

Since some games using OtpGo expect the packet order to be consistent, the MD queue is now a map of `QueueEntry` slices, and a `RouteDatagramEarly` function was added to append a datagram to the current QueueEntry slice. 

For now, this early routing is used for field updates (+ DB datagrams) and datagrams relevant to DO generation; it is possible that other datagram routing calls will need to update to use this later.