### PR TITLE
MD: make participants use a map to reduce memory allocations

### DIFF
--- a/messagedirector/md.go
+++ b/messagedirector/md.go
@@ -38,7 +38,7 @@ type MessageDirector struct {
 	previousAllocatedParticipantId atomic.Uint32
 
 
-	// MD participants may directly queue datagarams to be routed by adding it into the
+	// MD participants may directly queue datagrams to be routed by adding it into the
 	// queue map, where they will be processed asynchronously
 	Queue     map[uint32][]QueueEntry
 	queueLock sync.Mutex

--- a/messagedirector/md.go
+++ b/messagedirector/md.go
@@ -30,10 +30,16 @@ type MessageDirector struct {
 	// Connections within the context of the MessageDirector are represented as
 	// participants; however, clients and objects on the SS may function as participants
 	// as well. The MD will keep track of them and what channels they subscribe and route data to them.
-	participants []MDParticipant
+	// The IDs should not be assumed to be sequential, nor that a key will always hold the same participant.
+	participants *MutexMap[uint32, MDParticipant]
+	// freeParticipantIds contains IDs that were once allocated, but are now free to use. They take priority over assigning a new ID.
+	freeParticipantIds *MutexMap[uint32, bool]
+	// previousAllocatedParticipantId was the last ID assigned when a participant needed a fresh ID.
+	previousAllocatedParticipantId atomic.Uint32
 
-	// MD participants may directly queue datagarams to be routed by appending it into the
-	// queue slice, where they will be processed asynchronously
+
+	// MD participants may directly queue datagarams to be routed by adding it into the
+	// queue map, where they will be processed asynchronously
 	Queue     map[uint32][]QueueEntry
 	queueLock sync.Mutex
 	queueCurrentPosition atomic.Uint32
@@ -62,7 +68,9 @@ func Start() {
 	MD.queueCurrentPosition.Store(1)
 	MD.queuePreviousStoredPosition.Store(0)
 	MD.shouldProcess = make(chan bool)
-	MD.participants = make([]MDParticipant, 0)
+	MD.participants = NewMutexMap[uint32, MDParticipant]()
+	MD.freeParticipantIds = NewMutexMap[uint32, bool]()
+	MD.previousAllocatedParticipantId.Store(0)
 	MD.Handler = MD
 
 	channelMap := ChannelMap{}
@@ -237,12 +245,9 @@ func (m *MessageDirector) RecallPostRemoves() {
 
 func (m *MessageDirector) RemoveParticipant(p MDParticipant) {
 	m.Lock()
-	tempParticipantSlice := make([]MDParticipant, 0, cap(MD.participants))
-	for _, participant := range MD.participants {
-		if participant != p {
-			tempParticipantSlice = append(tempParticipantSlice, participant)
-		}
-	}
-	MD.participants = tempParticipantSlice
+	id := p.Id()
+	m.participants.Delete(id, false)
+	// Assign this ID for use later.
+	m.freeParticipantIds.Set(id, true, false)
 	m.Unlock()
 }

--- a/util/mutexstructs.go
+++ b/util/mutexstructs.go
@@ -65,6 +65,12 @@ func (mutexMap *MutexMap[keyType, valueType]) Delete(key keyType, holdLock bool)
 	delete(mutexMap.innerMap, key)
 }
 
+// DeleteNoLock deletes the key/value pair with the given key from the mutex map.
+// Should only be used if you've already acquired the write-lock, for example inside a WriteIterator.
+func (mutexMap *MutexMap[keyType, valueType]) DeleteNoLock(key keyType) {
+	delete(mutexMap.innerMap, key)
+}
+
 // Clear removes all key/value pairs from the mutex map.
 // If holdLock is true, then the mutex will not be unlocked automatically; call [MutexMap.Unlock] to unlock the mutex as needed.
 func (mutexMap *MutexMap[keyType, valueType]) Clear(holdLock bool) {


### PR DESCRIPTION
With the current codebase, every time a participant is removed from the participants slice, the slice has to be recreated as to allow participants to be garbage collected and not allow the slice to grow indefinitely. This means that `RemoveParticipant` causes heavy allocations every call, and has to go through a `for` loop that isn't very efficient.

I have converted this into a map which allows for easier deletion of a specific participant. Participants are now given IDs that they can be referenced by for deletion and other use. IDs are not necessarily sequential, as ones that are associated with participants that are now deleted are stored for reuse—this is to prevent potential problems if a server runs for a long time.