### PR TITLE
ca: adjust heartbeat reset per golang docs

### DIFF
--- a/clientagent/client.go
+++ b/clientagent/client.go
@@ -1090,9 +1090,8 @@ func (c *Client) queueLoop() {
 
 func (c *Client) handleHeartbeat() {
 	if c.config.Client.Heartbeat_Timeout != 0 {
-		// If the timer has already stopped, just stop it again to prevent potential issues.
-		if !c.heartbeat.Reset(time.Duration(c.config.Client.Heartbeat_Timeout) * time.Second) {
-			c.heartbeat.Stop()
+		if c.heartbeat.Stop() {
+			c.heartbeat.Reset(time.Duration(c.config.Client.Heartbeat_Timeout) * time.Second)
 		}
 	}
 }


### PR DESCRIPTION
“Note that it is not possible to use Reset's return value correctly, as there is a race condition between draining the channel and the new timer expiring. Reset should always be invoked on stopped or expired channels, as described above. The return value exists to preserve compatibility with existing programs.”

https://pkg.go.dev/time@go1.22.12#Timer.Reset