### PR TITLE
channelmap: Fix upstream MD routing to downstream CAs

### DIFF
--- a/messagedirector/channelmap.go
+++ b/messagedirector/channelmap.go
@@ -467,7 +467,7 @@ func (c *ChannelMap) SubscribeChannel(p *Subscriber, ch Channel_t) {
 
 	MDLog.Debugf("%s has subscribed to channel %d", p.participant.Name(), ch)
 
-	if subsLength == 1 {
+	if subsLength == 0 {
 		MD.AddChannel(ch)
 	}
 }


### PR DESCRIPTION
In channelmap, we count the channel subscribers before we add the participant as a subscriber, this means at the time of checking, the amount of subscribers for a new channel should be 0 instead of 1. This had the effect of causing any downstream CAs connecting to the MD being able to route messages upstream, but never receiving anything downstream. 