### PR TITLE
Add auto-build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build for all platforms
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: '1.27'
+      - name: Build all binaries
+        run: ./build_all.sh
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: otpgo-binaries
+          path: build
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ otpgo
 *.so
 *.dylib
 
+# Output build directory
+build
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/build_all.sh
+++ b/build_all.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Build all platforms that are known to be in use for OTPGo.
+set -euo pipefail
+
+cd "$(cd "$(dirname "$0")" && pwd)"
+
+if ! command -v go >/dev/null 2>&1; then
+    echo "error: go is not installed or not on PATH" >&2
+    exit 1
+fi
+
+OUT_DIR="build"
+mkdir -p "$OUT_DIR"
+
+LDFLAGS="-s -w"
+
+build() {
+    local goos="$1" goarch="$2" out="$3"
+    echo "==> Building $out ($goos/$goarch)"
+    GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 \
+        go build -trimpath -ldflags="$LDFLAGS" -o "$OUT_DIR/$out" .
+}
+
+build darwin  amd64 otpgo_darwin
+build darwin  arm64 otpgo_darwin_arm
+build linux   amd64 otpgo_linux
+build linux   arm64 otpgo_linux_arm
+build windows amd64 otpgo.exe
+
+chmod -R +x "$OUT_DIR"
+
+echo
+echo "Build complete. Binaries are in $(pwd)/$OUT_DIR:"
+ls -la "$OUT_DIR"
+
+if [ -t 0 ]; then
+    read -rp $'\nPress Enter to close...'
+fi


### PR DESCRIPTION
Now that there's no CGo and SWIG, this is trivial.

:D

This pull request adds an auto-build pipeline that builds for the five most important platforms: the two MacOS archs, the two Linux archs and Windows x64. (sorry Rocket's Snapdragon lappy).

All the platforms are saved into one artifact (`otpgo-binaries.zip`).

Thanks Jace again.