### PR TITLE
Fix possible fix(deps): 15 vulnerable dependencies in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,11 +65,11 @@ require (
 	github.com/yuin/gluamapper v0.0.0-20150323120927-d836955830e7 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.43.0 // indirect
-	golang.org/x/net v0.46.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.37.0 // indirect
-	golang.org/x/text v0.30.0 // indirect
+	golang.org/x/text v0.39.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/xmlpath.v2 v2.0.0-20150820204837-860cbeca3ebc // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
This changes `go.mod` to address something a scan flagged. It is around line 1.

The project depends on golang.org/x/net v0.46.0, which contains a vulnerability (CVE-2026-25681) that allows malicious HTML to be parsed and later rendered, leading to potential cross‑site scripting (XSS) attacks. Because the vulnerable code can be triggered simply by feeding crafted HTML to the parser, the impact is high and the risk level is classified as HIGH. Updating to a version where the bug is fixed (>= v0.55.0) eliminates the unsafe parsing behavior and protects applications that render user‑supplied HTML.

Update three indirect dependencies to versions fixing reported CVEs.

For reference: rule `CVE-2026-25681`. Rated high.

I do not know the codebase, so please check the change fits how the rest of it works. Happy to adjust it or close this if the reasoning is off.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
